### PR TITLE
fix warnings for the mcx_core kernel

### DIFF
--- a/src/mcx_core.cl
+++ b/src/mcx_core.cl
@@ -94,7 +94,6 @@ typedef struct KernelParams {
 
 
 void logistic_step(__private RandType *t, __private RandType *tnew, int len_1){
-    RandType tmp;
     t[0]=FUN(t[0]);
     t[1]=FUN(t[1]);
     t[2]=FUN(t[2]);
@@ -218,7 +217,7 @@ int launchnewphoton(float4 p[],float4 v[],float4 f[],float4 prop[],uint *idx1d,
 	 clearpath(ppath,gcfg);
       }
 #endif
-      if(f->w>=(threadphoton+(threadid<oddphotons)))
+      if(f[0]->w>=(threadphoton+(threadid<oddphotons)))
          return 1; // all photons complete 
       p[0]=gcfg->ps;
       v[0]=gcfg->c0;


### PR DESCRIPTION
1) warning, tmp was declared but never refereced
2)expression must have pointer-to-struct-or-union type