### PR TITLE
optimize photon workload at work-group level

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,8 @@ OUTPUT_DIR=../bin
 INCLUDEDIRS=#-I/home/fangq/Download/ati-stream-sdk-v2.0-lnx32/include
 AMDAPPSDKROOT ?=/opt/AMDAPPSDK-2.9-1
 LIBOPENCLDIR ?=$(AMDAPPSDKROOT)/lib/x86_64
-LINKOPT=-g -L$(LIBOPENCLDIR) -lOpenCL
+CUDAOPENCLDIR ?=/usr/local/cuda/lib64
+LINKOPT=-g -L$(LIBOPENCLDIR) -L$(CUDAOPENCLDIR) -lOpenCL
 
 CUCCOPT=-I/usr/local/cuda/include #-m32 -msse2 -Wfloat-equal -Wpointer-arith  -DATI_OS_LINUX -g3 -ffor-scope 
 CCOPT=-g -pedantic -Wall -O3 -DMCX_OPENCL -DUSE_OS_TIMER -I/usr/local/cuda/include  -std=c99#-O3

--- a/src/mcx_host.cpp
+++ b/src/mcx_host.cpp
@@ -423,8 +423,12 @@ $MCXCL$Rev::    $ Last Commit $Date::                     $ by $Author:: fangq$\
 
      mcxkernel=(cl_kernel*)malloc(workdev*sizeof(cl_kernel));
 
+	 int photons_per_blk;
      for(i=0;i<workdev;i++){
          cl_int threadphoton, oddphotons;
+
+		 int blocks = ((gpu[i].autothread + gpu[i].autoblock - 1 ) / gpu[i].autoblock);
+		 photons_per_blk = ((cfg->nphoton + blocks - 1 ) /  blocks);
 
          threadphoton=(int)(cfg->nphoton*cfg->workload[i]/(fullload*gpu[i].autothread*cfg->respin));
          oddphotons=(int)(cfg->nphoton*cfg->workload[i]/(fullload*cfg->respin)-threadphoton*gpu[i].autothread);
@@ -432,8 +436,8 @@ $MCXCL$Rev::    $ Last Commit $Date::                     $ by $Author:: fangq$\
                cfg->nphoton*cfg->workload[i]/fullload,(int)gpu[i].autothread,cfg->respin);
 
 	 OCL_ASSERT(((mcxkernel[i] = clCreateKernel(mcxprogram, "mcx_main_loop", &status),status)));
-	 OCL_ASSERT((clSetKernelArg(mcxkernel[i], 0, sizeof(cl_uint),(void*)&threadphoton)));
-         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 1, sizeof(cl_uint),(void*)&oddphotons)));
+	 OCL_ASSERT((clSetKernelArg(mcxkernel[i], 0, sizeof(cl_int), (void*)&photons_per_blk)));
+     OCL_ASSERT((clSetKernelArg(mcxkernel[i], 1, sizeof(cl_uint),(void*)&oddphotons)));
 	 OCL_ASSERT((clSetKernelArg(mcxkernel[i], 2, sizeof(cl_mem), (void*)&gmedia)));
 	 OCL_ASSERT((clSetKernelArg(mcxkernel[i], 3, sizeof(cl_mem), (void*)(gfield+i))));
 	 OCL_ASSERT((clSetKernelArg(mcxkernel[i], 4, sizeof(cl_mem), (void*)(genergy+i))));


### PR DESCRIPTION
Use local memory to dynamically distribute workloads to each thread in the work-group.
The OpenCL lib directory for cuda is added to the Makefile.