### PR TITLE
fix excess buffer release and add missing ones

### DIFF
--- a/src/mcx_host.cpp
+++ b/src/mcx_host.cpp
@@ -764,17 +764,23 @@ is more than what your have specified (%d), please use the -H option to specify 
      for(i=0;i<workdev;i++){
          clReleaseMemObject(gfield[i]);
          clReleaseMemObject(gseed[i]);
+         clReleaseMemObject(gdetphoton[i]);
          clReleaseMemObject(genergy[i]);
          clReleaseMemObject(gdetected[i]);
-         clReleaseMemObject(gdetpos[i]);
+         if(cfg->detpos)
+             clReleaseMemObject(gdetpos[i]);
+         if(cfg->srctype==MCX_SRC_PATTERN || cfg->srctype==MCX_SRC_PATTERN3D)
+             clReleaseMemObject(gsrcpattern[i]);
          clReleaseKernel(mcxkernel[i]);
      }
      free(gfield);
      free(gseed);
+     free(gdetphoton);
      free(genergy);
      free(gprogress);
      free(gdetected);
      free(gdetpos);
+     free(gsrcpattern);
      free(mcxkernel);
 
      free(waittoread);


### PR DESCRIPTION
This fixes the memory leak (significant when MCXCL is embedded in another process) and wipes out the errors on API call (raised when attempt to release buffers never created).